### PR TITLE
Add import sorter

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,9 @@
   "singleQuote": true,
   "printWidth": 80,
   "tabWidth": 2,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "plugins": ["prettier-plugin-sort-imports"],
+  "importOrder": ["^react", "^[./]"],
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "jest": "^29.7.0",
         "postcss": "^8",
         "prettier": "^3.5.3",
+        "prettier-plugin-sort-imports": "^1.8.7",
         "tailwindcss": "^3.4.1",
         "ts-jest": "^29.2.4",
         "typescript": "^5"
@@ -6899,6 +6900,19 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-sort-imports": {
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-1.8.7.tgz",
+      "integrity": "sha512-MG+3+bh+ZGtkxwcYiFsqU7XRVAK8wDjoKuaSS7UZA/UOxPP1h+et1/yJCZAammWydP26FIsXFtm7zenycKfk8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier": "^3.1.1"
+      },
+      "peerDependencies": {
+        "typescript": ">4.0.0"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team-division",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -27,6 +27,7 @@
     "jest": "^29.7.0",
     "postcss": "^8",
     "prettier": "^3.5.3",
+    "prettier-plugin-sort-imports": "^1.8.7",
     "tailwindcss": "^3.4.1",
     "ts-jest": "^29.2.4",
     "typescript": "^5"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
-import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
+import type { Metadata } from 'next'
 import './globals.css'
 
 const inter = Inter({ subsets: ['latin'] })

--- a/test/utils/player.test.ts
+++ b/test/utils/player.test.ts
@@ -1,5 +1,5 @@
-import { Player } from '../../utils/player'
 import { tierEnum, rankEnum, calcurateRating } from '../../utils/rank'
+import { Player } from '../../utils/player'
 
 describe('Player', () => {
   let player: Player

--- a/test/utils/team-divider.test.ts
+++ b/test/utils/team-divider.test.ts
@@ -1,106 +1,106 @@
-import { TeamDivider } from '../../utils/team-divider';
-import { Player } from '../../utils/player';
-import { tierEnum, rankEnum } from '../../utils/rank';
+import { TeamDivider } from '../../utils/team-divider'
+import { tierEnum, rankEnum } from '../../utils/rank'
+import { Player } from '../../utils/player'
 
 describe('TeamDivider', () => {
-  let teamDivider: TeamDivider;
+  let teamDivider: TeamDivider
 
   beforeEach(() => {
-    teamDivider = new TeamDivider();
-  });
+    teamDivider = new TeamDivider()
+  })
 
   describe('addPlayer', () => {
     it('プレイヤーを追加できることを確認する', () => {
-      const player = new Player('Player1', 'Tag#1234');
-      teamDivider.addPlayer(player);
+      const player = new Player('Player1', 'Tag#1234')
+      teamDivider.addPlayer(player)
 
-      expect(teamDivider.getPlayers()).toHaveLength(1);
-      expect(teamDivider.getPlayers()[0].getName()).toBe('Player1');
-    });
+      expect(teamDivider.getPlayers()).toHaveLength(1)
+      expect(teamDivider.getPlayers()[0].getName()).toBe('Player1')
+    })
 
     it('プレイヤーが最大数を超える場合、エラーがスローされることを確認する', () => {
       for (let i = 0; i < 10; i++) {
-        teamDivider.addPlayer(new Player(`Player${i + 1}`, `Tag#${i + 1}`));
+        teamDivider.addPlayer(new Player(`Player${i + 1}`, `Tag#${i + 1}`))
       }
 
       expect(() =>
         teamDivider.addPlayer(new Player('ExtraPlayer', 'Tag#9999'))
-      ).toThrow('Cannot add more players. Maximum limit reached.');
-    });
-  });
+      ).toThrow('Cannot add more players. Maximum limit reached.')
+    })
+  })
 
   describe('removePlayer', () => {
     it('プレイヤーを削除できることを確認する', () => {
-      const player1 = new Player('Player1', 'Tag#1234');
-      const player2 = new Player('Player2', 'Tag#5678');
-      teamDivider.addPlayer(player1);
-      teamDivider.addPlayer(player2);
+      const player1 = new Player('Player1', 'Tag#1234')
+      const player2 = new Player('Player2', 'Tag#5678')
+      teamDivider.addPlayer(player1)
+      teamDivider.addPlayer(player2)
 
-      teamDivider.removePlayer(0);
+      teamDivider.removePlayer(0)
 
-      expect(teamDivider.getPlayers()).toHaveLength(1);
-      expect(teamDivider.getPlayers()[0].getName()).toBe('Player2');
-    });
+      expect(teamDivider.getPlayers()).toHaveLength(1)
+      expect(teamDivider.getPlayers()[0].getName()).toBe('Player2')
+    })
 
     it('無効なインデックスでプレイヤーを削除しようとするとエラーがスローされることを確認する', () => {
-      expect(() => teamDivider.removePlayer(0)).toThrow('Invalid index');
-    });
-  });
+      expect(() => teamDivider.removePlayer(0)).toThrow('Invalid index')
+    })
+  })
 
   describe('isDividable', () => {
     it('プレイヤーが10人未満の場合、チーム分けができないことを確認する', () => {
       for (let i = 0; i < 9; i++) {
-        teamDivider.addPlayer(new Player(`Player${i + 1}`, `Tag#${i + 1}`));
+        teamDivider.addPlayer(new Player(`Player${i + 1}`, `Tag#${i + 1}`))
       }
 
-      expect(teamDivider.isDividable()).toBe(false);
-    });
+      expect(teamDivider.isDividable()).toBe(false)
+    })
 
     it('プレイヤーが10人の場合、チーム分けが可能であることを確認する', () => {
       for (let i = 0; i < 10; i++) {
-        teamDivider.addPlayer(new Player(`Player${i + 1}`, `Tag#${i + 1}`));
+        teamDivider.addPlayer(new Player(`Player${i + 1}`, `Tag#${i + 1}`))
       }
 
-      expect(teamDivider.isDividable()).toBe(true);
-    });
-  });
+      expect(teamDivider.isDividable()).toBe(true)
+    })
+  })
 
   describe('divideTeams', () => {
     it('5000回の試行で希望に合わない人数ごとの最適なチーム分けが登録されることを確認する', () => {
       for (let i = 0; i < 10; i++) {
-        const player = new Player(`Player${i + 1}`, `Tag#${i + 1}`);
-        player.setRank(tierEnum.gold, rankEnum.one);
-        teamDivider.addPlayer(player);
+        const player = new Player(`Player${i + 1}`, `Tag#${i + 1}`)
+        player.setRank(tierEnum.gold, rankEnum.one)
+        teamDivider.addPlayer(player)
       }
 
-      teamDivider.divideTeams();
+      teamDivider.divideTeams()
 
-      const teamDivisions = teamDivider.getTeamDivisions();
-      expect(Object.keys(teamDivisions)).toHaveLength(11); // 0～10のキーが存在する
+      const teamDivisions = teamDivider.getTeamDivisions()
+      expect(Object.keys(teamDivisions)).toHaveLength(11) // 0～10のキーが存在する
       for (let mismatchCount = 0; mismatchCount <= 10; mismatchCount++) {
-        const division = teamDivisions[mismatchCount];
-        expect(division).toHaveProperty('players');
-        expect(division).toHaveProperty('ratingDifference');
+        const division = teamDivisions[mismatchCount]
+        expect(division).toHaveProperty('players')
+        expect(division).toHaveProperty('ratingDifference')
         if (division.players.length > 0) {
-          expect(division.players).toHaveLength(10);
+          expect(division.players).toHaveLength(10)
         }
       }
-    });
-  });
+    })
+  })
 
   describe('getTeamDivisions', () => {
     it('希望に合わない人数ごとのチーム分けが取得できることを確認する', () => {
       for (let i = 0; i < 10; i++) {
-        const player = new Player(`Player${i + 1}`, `Tag#${i + 1}`);
-        player.setRank(tierEnum.gold, rankEnum.one);
-        teamDivider.addPlayer(player);
+        const player = new Player(`Player${i + 1}`, `Tag#${i + 1}`)
+        player.setRank(tierEnum.gold, rankEnum.one)
+        teamDivider.addPlayer(player)
       }
 
-      teamDivider.divideTeams();
+      teamDivider.divideTeams()
 
-      const teamDivisions = teamDivider.getTeamDivisions();
-      expect(teamDivisions).toBeDefined();
-      expect(Object.keys(teamDivisions)).toHaveLength(11); // 0～10のキーが存在する
-    });
-  });
-});
+      const teamDivisions = teamDivider.getTeamDivisions()
+      expect(teamDivisions).toBeDefined()
+      expect(Object.keys(teamDivisions)).toHaveLength(11) // 0～10のキーが存在する
+    })
+  })
+})

--- a/utils/team-divider.ts
+++ b/utils/team-divider.ts
@@ -1,16 +1,19 @@
-import { Player } from './player';
+import { Player } from './player'
 
 export class TeamDivider {
-  private static readonly TEAM_SIZE = 5;
-  private static readonly TOTAL_PLAYERS = 10;
+  private static readonly TEAM_SIZE = 5
+  private static readonly TOTAL_PLAYERS = 10
 
-  private players: Player[] = [];
-  private teamDivisions: Record<number, { players: Player[]; ratingDifference: number }> = {};
+  private players: Player[] = []
+  private teamDivisions: Record<
+    number,
+    { players: Player[]; ratingDifference: number }
+  > = {}
 
   constructor() {
     // teamDivisions を 0 から 10 のキーで初期化
     for (let i = 0; i <= TeamDivider.TOTAL_PLAYERS; i++) {
-      this.teamDivisions[i] = { players: [], ratingDifference: Infinity };
+      this.teamDivisions[i] = { players: [], ratingDifference: Infinity }
     }
   }
 
@@ -20,9 +23,9 @@ export class TeamDivider {
    */
   addPlayer(player: Player): void {
     if (this.players.length >= TeamDivider.TOTAL_PLAYERS) {
-      throw new Error('Cannot add more players. Maximum limit reached.');
+      throw new Error('Cannot add more players. Maximum limit reached.')
     }
-    this.players.push(player);
+    this.players.push(player)
   }
 
   /**
@@ -31,9 +34,9 @@ export class TeamDivider {
    */
   removePlayer(index: number): void {
     if (index < 0 || index >= this.players.length) {
-      throw new Error('Invalid index');
+      throw new Error('Invalid index')
     }
-    this.players.splice(index, 1);
+    this.players.splice(index, 1)
   }
 
   /**
@@ -41,15 +44,18 @@ export class TeamDivider {
    * @returns プレイヤーの配列
    */
   getPlayers(): Player[] {
-    return [...this.players];
+    return [...this.players]
   }
 
   /**
    * 希望に合わない人数ごとの最適なチーム分けを取得する
    * @returns 希望に合わない人数をキーにしたチーム分けの辞書
    */
-  getTeamDivisions(): Record<number, { players: Player[]; ratingDifference: number }> {
-    return this.teamDivisions;
+  getTeamDivisions(): Record<
+    number,
+    { players: Player[]; ratingDifference: number }
+  > {
+    return this.teamDivisions
   }
 
   /**
@@ -57,7 +63,7 @@ export class TeamDivider {
    * @returns 分けられる場合は true、それ以外は false
    */
   isDividable(): boolean {
-    return this.players.length === TeamDivider.TOTAL_PLAYERS;
+    return this.players.length === TeamDivider.TOTAL_PLAYERS
   }
 
   /**
@@ -65,18 +71,18 @@ export class TeamDivider {
    */
   divideTeams(): void {
     if (!this.isDividable()) {
-      throw new Error('Cannot divide teams with the current players');
+      throw new Error('Cannot divide teams with the current players')
     }
 
     // 5000回チーム分けを試行
     for (let i = 0; i < 5000; i++) {
-      const { players, mismatchCount, ratingDifference } = this._createTeams();
+      const { players, mismatchCount, ratingDifference } = this._createTeams()
 
       // 希望に合わない人数をキーに辞書を更新
       if (
         ratingDifference < this.teamDivisions[mismatchCount].ratingDifference
       ) {
-        this.teamDivisions[mismatchCount] = { players, ratingDifference };
+        this.teamDivisions[mismatchCount] = { players, ratingDifference }
       }
     }
   }
@@ -85,21 +91,25 @@ export class TeamDivider {
    * チームを作成し、希望に合わない人数を計算する
    * @returns 作成されたプレイヤーの並び、希望に合わない人数、レーティング差
    */
-  private _createTeams(): { players: Player[]; mismatchCount: number; ratingDifference: number } {
-    const shuffledPlayers = [...this.players];
-    this._shufflePlayers(shuffledPlayers);
+  private _createTeams(): {
+    players: Player[]
+    mismatchCount: number
+    ratingDifference: number
+  } {
+    const shuffledPlayers = [...this.players]
+    this._shufflePlayers(shuffledPlayers)
 
-    let mismatchCount = 0;
+    let mismatchCount = 0
 
     for (let i = 0; i < shuffledPlayers.length; i++) {
       if (shuffledPlayers[i].getDesiredRole()[i % 5] === 0) {
-        mismatchCount++;
+        mismatchCount++
       }
     }
 
-    const ratingDifference = this._calculateRatingDifference(shuffledPlayers);
+    const ratingDifference = this._calculateRatingDifference(shuffledPlayers)
 
-    return { players: shuffledPlayers, mismatchCount, ratingDifference };
+    return { players: shuffledPlayers, mismatchCount, ratingDifference }
   }
 
   /**
@@ -108,8 +118,8 @@ export class TeamDivider {
    */
   private _shufflePlayers(players: Player[]): void {
     for (let i = players.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [players[i], players[j]] = [players[j], players[i]];
+      const j = Math.floor(Math.random() * (i + 1))
+      ;[players[i], players[j]] = [players[j], players[i]]
     }
   }
 
@@ -121,10 +131,10 @@ export class TeamDivider {
   private _calculateRatingDifference(players: Player[]): number {
     const blueTeamRating = players
       .slice(0, TeamDivider.TEAM_SIZE)
-      .reduce((total, player) => total + player.getRating(), 0);
+      .reduce((total, player) => total + player.getRating(), 0)
     const redTeamRating = players
       .slice(TeamDivider.TEAM_SIZE)
-      .reduce((total, player) => total + player.getRating(), 0);
-    return Math.abs(blueTeamRating - redTeamRating);
+      .reduce((total, player) => total + player.getRating(), 0)
+    return Math.abs(blueTeamRating - redTeamRating)
   }
 }


### PR DESCRIPTION
This pull request includes several updates aimed at improving code consistency and functionality. The most significant changes involve the addition of a Prettier plugin for sorting imports, updating the project version, and ensuring consistent import ordering across multiple files.

### Code Consistency and Formatting:

* [`.prettierrc`](diffhunk://#diff-663ade211b3a1552162de21c4031fcd16be99407aae5ceecbb491a2efc43d5d2L6-R10): Added `prettier-plugin-sort-imports` and configured import order to prioritize React imports and local imports, with separation and sorting of specifiers enabled.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated project version to `1.0.0` and added `prettier-plugin-sort-imports` as a development dependency. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R30)

### Import Order Adjustments:

* [`src/app/layout.tsx`](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L1-R2): Adjusted import order to place type imports after functional imports.
* [`test/utils/player.test.ts`](diffhunk://#diff-64df10d908b4769bbb44c5fc2e2733813d394bb56db57c7269768381dc294330L1-R2): Reordered imports to follow the new import order rules.
* [`test/utils/team-divider.test.ts`](diffhunk://#diff-cf7bd0f6669077b62202ef5081f59b5baba5aa6aad8ff4591a2c615ef6cbb462L1-R106): Reordered and formatted imports for consistency.

### Code Style Improvements:

* [`utils/team-divider.ts`](diffhunk://#diff-38b5dcf914b09bca0fc216bbfc30c6eadc2d4128bb400ad8ce3c285cc266c653L1-R16): Reformatted code to remove semicolons and ensure consistent use of single quotes. This includes changes in method definitions and internal logic for team division and player management. [[1]](diffhunk://#diff-38b5dcf914b09bca0fc216bbfc30c6eadc2d4128bb400ad8ce3c285cc266c653L1-R16) [[2]](diffhunk://#diff-38b5dcf914b09bca0fc216bbfc30c6eadc2d4128bb400ad8ce3c285cc266c653L23-R28) [[3]](diffhunk://#diff-38b5dcf914b09bca0fc216bbfc30c6eadc2d4128bb400ad8ce3c285cc266c653L34-R85) [[4]](diffhunk://#diff-38b5dcf914b09bca0fc216bbfc30c6eadc2d4128bb400ad8ce3c285cc266c653L88-R112) [[5]](diffhunk://#diff-38b5dcf914b09bca0fc216bbfc30c6eadc2d4128bb400ad8ce3c285cc266c653L111-R122) [[6]](diffhunk://#diff-38b5dcf914b09bca0fc216bbfc30c6eadc2d4128bb400ad8ce3c285cc266c653L124-R138)